### PR TITLE
Refactor codebase and add unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# callot
+# Callot
+
+Callot is a command line application for calculating trading lot sizes based on
+predefined risk settings. It stores its configuration in
+`~/.config/callot/config.json` and provides a simple interactive interface as
+well as a set of subcommands for managing that configuration.
+
+## Installation
+
+```
+go install github.com/chiyonn/callot@latest
+```
+
+## Usage
+
+Running `callot` without arguments launches the interactive mode. The program
+will prompt you for a currency pair, the loss-cut width and the take-profit
+ratio and will then display the maximum allowable trading volume.
+
+All configuration can be adjusted via subcommands:
+
+```
+callot config show            # display current settings
+callot config add-pair USDJPY # register a currency pair
+callot config set-margin 40   # set margin amount (40 means 400000 JPY)
+callot config set-risk 1.6    # set risk tolerance percentage
+callot config set-ratio 2     # set default take-profit ratio
+```
+
+## Development
+
+A prebuilt binary is included for convenience, but you can build everything from
+source using `go build`.

--- a/cmd/add_pair.go
+++ b/cmd/add_pair.go
@@ -20,22 +20,22 @@ var addPairCmd = &cobra.Command{
       os.Exit(1)
     }
 
-    cfg, err := config.Load()
+    conf, err := config.Load()
     if err != nil {
       fmt.Println("Failed to load config:", err)
       os.Exit(1)
     }
 
-    for _, p := range cfg.Pairs {
+    for _, p := range conf.Pairs {
       if p == symbol {
         fmt.Printf("Pair %s already exists.\n", symbol)
         return
       }
     }
 
-    cfg.Pairs = append(cfg.Pairs, symbol)
+    conf.Pairs = append(conf.Pairs, symbol)
 
-    if err := config.Save(cfg); err != nil {
+    if err := config.Save(conf); err != nil {
       fmt.Println("Failed to save config:", err)
       os.Exit(1)
     }

--- a/cmd/set_margin.go
+++ b/cmd/set_margin.go
@@ -20,20 +20,20 @@ var setMarginCmd = &cobra.Command{
       os.Exit(1)
     }
 
-    cfg, err := config.Load()
+    conf, err := config.Load()
     if err != nil {
       fmt.Println("Failed to load config:", err)
       os.Exit(1)
     }
 
-    cfg.Margin = percent * 10000
+    conf.Margin = percent * 10000
 
-    if err := config.Save(cfg); err != nil {
+    if err := config.Save(conf); err != nil {
       fmt.Println("Failed to save config:", err)
       os.Exit(1)
     }
 
-    fmt.Printf("Margin set to %d (= %d JPY).\n", percent, cfg.Margin)
+    fmt.Printf("Margin set to %d (= %d JPY).\n", percent, conf.Margin)
   },
 }
 

--- a/cmd/set_ratio.go
+++ b/cmd/set_ratio.go
@@ -20,15 +20,15 @@ var setRatioCmd = &cobra.Command{
       os.Exit(1)
     }
 
-    cfg, err := config.Load()
+    conf, err := config.Load()
     if err != nil {
       fmt.Println("Failed to load config:", err)
       os.Exit(1)
     }
 
-    cfg.TakeProfitRatio = ratio
+    conf.TakeProfitRatio = ratio
 
-    if err := config.Save(cfg); err != nil {
+    if err := config.Save(conf); err != nil {
       fmt.Println("Failed to save config:", err)
       os.Exit(1)
     }

--- a/cmd/set_risk.go
+++ b/cmd/set_risk.go
@@ -20,20 +20,20 @@ var setRiskCmd = &cobra.Command{
       os.Exit(1)
     }
 
-    cfg, err := config.Load()
+    conf, err := config.Load()
     if err != nil {
       fmt.Println("Failed to load config:", err)
       os.Exit(1)
     }
 
-    cfg.RiskTolerance = percent / 100.0
+    conf.RiskTolerance = percent / 100.0
 
-    if err := config.Save(cfg); err != nil {
+    if err := config.Save(conf); err != nil {
       fmt.Println("Failed to save config:", err)
       os.Exit(1)
     }
 
-    fmt.Printf("Risk tolerance set to %.2f%% (%.4f internally)\n", percent, cfg.RiskTolerance)
+    fmt.Printf("Risk tolerance set to %.2f%% (%.4f internally)\n", percent, conf.RiskTolerance)
   },
 }
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -11,20 +11,20 @@ var showCmd = &cobra.Command{
   Use:   "show",
   Short: "Display current configuration",
   Run: func(cmd *cobra.Command, args []string) {
-    cfg, err := config.Load()
+    conf, err := config.Load()
     if err != nil {
       fmt.Println("Failed to load config:", err)
       return
     }
 
     fmt.Println("Current Configuration:")
-    fmt.Printf("  Margin: %d (= %d JPY)\n", cfg.Margin/10000, cfg.Margin)
+    fmt.Printf("  Margin: %d (= %d JPY)\n", conf.Margin/10000, conf.Margin)
 
-    if len(cfg.Pairs) == 0 {
+    if len(conf.Pairs) == 0 {
       fmt.Println("  Currency Pairs: (none)")
     } else {
       fmt.Println("  Currency Pairs:")
-      for _, p := range cfg.Pairs {
+      for _, p := range conf.Pairs {
         fmt.Printf("    - %s\n", p)
       }
     }

--- a/internal/calculator/calculator_test.go
+++ b/internal/calculator/calculator_test.go
@@ -1,0 +1,44 @@
+package calculator
+
+import (
+    "testing"
+
+    "github.com/chiyonn/callot/internal/config"
+)
+
+func TestNewCalculator(t *testing.T) {
+    conf := &config.Config{Margin: 100000, RiskTolerance: 0.02, SelectedPair: "USDJPY"}
+    calc := New(conf)
+
+    if calc.riskTolerance != 0.02 {
+        t.Fatalf("riskTolerance expected 0.02 got %f", calc.riskTolerance)
+    }
+    expected := float64(conf.Margin) * 0.02
+    if calc.maxLossJPY != expected {
+        t.Fatalf("maxLossJPY expected %f got %f", expected, calc.maxLossJPY)
+    }
+    if calc.pair == nil || calc.pair.Base != "USD" {
+        t.Fatalf("unexpected pair: %+v", calc.pair)
+    }
+}
+
+func TestNewCalculatorDefaultRisk(t *testing.T) {
+    conf := &config.Config{Margin: 200000, SelectedPair: "EURUSD"}
+    calc := New(conf)
+
+    if calc.riskTolerance != 0.01 {
+        t.Fatalf("default riskTolerance expected 0.01 got %f", calc.riskTolerance)
+    }
+    expected := float64(conf.Margin) * 0.01
+    if calc.maxLossJPY != expected {
+        t.Fatalf("maxLossJPY expected %f got %f", expected, calc.maxLossJPY)
+    }
+}
+
+func TestNewCalculatorInvalidPair(t *testing.T) {
+    conf := &config.Config{Margin: 100000, SelectedPair: "BAD"}
+    calc := New(conf)
+    if calc.pair != nil {
+        t.Fatalf("expected nil pair for invalid input")
+    }
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,10 +19,10 @@ type Config struct {
   PrimaryCurrency string   `json:"primaryCurrency"`
 }
 
-var defaultPath = filepath.Join(os.Getenv("HOME"), ".config", "callot", "config.json")
+var configFilePath = filepath.Join(os.Getenv("HOME"), ".config", "callot", "config.json")
 
 func Load() (*Config, error) {
-  data, err := os.ReadFile(defaultPath)
+  data, err := os.ReadFile(configFilePath)
   if err != nil {
     if errors.Is(err, os.ErrNotExist) {
       return &Config{Margin: 0, Pairs: []string{}}, nil // initialize with empty list
@@ -44,7 +44,7 @@ func Load() (*Config, error) {
 }
 
 func Save(cfg *Config) error {
-  dir := filepath.Dir(defaultPath)
+  dir := filepath.Dir(configFilePath)
   if err := os.MkdirAll(dir, 0755); err != nil {
     return err
   }
@@ -54,5 +54,5 @@ func Save(cfg *Config) error {
     return err
   }
 
-  return os.WriteFile(defaultPath, data, 0644)
+  return os.WriteFile(configFilePath, data, 0644)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+    "path/filepath"
+    "reflect"
+    "testing"
+)
+
+func TestSaveAndLoad(t *testing.T) {
+    tmp := t.TempDir()
+    configFilePath = filepath.Join(tmp, "config.json")
+
+    original := &Config{
+        Margin:          100,
+        Pairs:           []string{"USDJPY"},
+        SelectedPair:    "USDJPY",
+        LossCutPips:     10,
+        TakeProfitRatio: 2,
+        RiskTolerance:   0.02,
+    }
+
+    if err := Save(original); err != nil {
+        t.Fatalf("save failed: %v", err)
+    }
+
+    loaded, err := Load()
+    if err != nil {
+        t.Fatalf("load failed: %v", err)
+    }
+
+    if !reflect.DeepEqual(original, loaded) {
+        t.Fatalf("loaded config mismatch: %+v vs %+v", original, loaded)
+    }
+}
+
+func TestLoadDefaultWhenMissing(t *testing.T) {
+    tmp := t.TempDir()
+    configFilePath = filepath.Join(tmp, "config.json")
+
+    cfg, err := Load()
+    if err != nil {
+        t.Fatalf("load failed: %v", err)
+    }
+
+    if cfg.Margin != 0 || len(cfg.Pairs) != 0 {
+        t.Fatalf("unexpected defaults: %+v", cfg)
+    }
+}

--- a/internal/model/currency_pair_test.go
+++ b/internal/model/currency_pair_test.go
@@ -1,0 +1,34 @@
+package model
+
+import "testing"
+
+func TestNewCurrencyPair(t *testing.T) {
+    cp, err := NewCurrencyPair("EURUSD")
+    if err != nil {
+        t.Fatalf("unexpected error: %v", err)
+    }
+    if cp.Base != "EUR" || cp.Quote != "USD" {
+        t.Fatalf("unexpected pair: %+v", cp)
+    }
+    if cp.String() != "EUR/USD" {
+        t.Fatalf("unexpected string: %s", cp.String())
+    }
+}
+
+func TestNewCurrencyPairInvalid(t *testing.T) {
+    if _, err := NewCurrencyPair("BAD"); err == nil {
+        t.Fatal("expected error for invalid pair")
+    }
+}
+
+func TestPipValue(t *testing.T) {
+    jpyPair, _ := NewCurrencyPair("USDJPY")
+    if v := jpyPair.PipValue(); v != 0.01 {
+        t.Fatalf("unexpected pip value: %f", v)
+    }
+
+    usdPair, _ := NewCurrencyPair("EURUSD")
+    if v := usdPair.PipValue(); v != 0.0001 {
+        t.Fatalf("unexpected pip value: %f", v)
+    }
+}


### PR DESCRIPTION
## Summary
- rename config path variable for clarity
- refine calculator struct and variable naming
- update command files to use clearer variable names
- expand README with usage and installation details
- add unit tests for config handling, calculator logic and currency pair model

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68899d1b3fbc833286afda8b4991a50c